### PR TITLE
Update Gemstone-Crab

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ For issues, suggestions, or contributions, please open an issue on the GitHub re
 
 ## Changelog
 
+### V1.1.3
+- Fix: Also reset tunnel highlight when boss respawns (same area)
+- Fix: Changed time left & notification to use getHealthRatio and getHealthScale instead of reading widget, this allows all HP bar configurations to work
+- Removed unused variables, imports and now redundant methods
+
 ### V1.1.2
 - Messages now show [Gemstone Crab] in front of them
 - Fix issues with threshold notification settings

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 }
 
 group = 'com.gimserenity'
-version = '1.1.2'
+version = '1.1.3'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/com/gimserenity/GemstoneCrabTimerPlugin.java
+++ b/src/main/java/com/gimserenity/GemstoneCrabTimerPlugin.java
@@ -14,7 +14,6 @@ import net.runelite.api.NPC;
 import net.runelite.api.Skill;
 import net.runelite.api.WorldView;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.IndexedObjectSet;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameObjectDespawned;
 import net.runelite.api.events.GameObjectSpawned;
@@ -121,10 +120,6 @@ public class GemstoneCrabTimerPlugin extends Plugin
 	
 	// Track if the boss is present
 	private boolean bossPresent = false;
-
-	private boolean fightEnded = false;
-
-	private boolean AFK = true;
 
 	// Track if we should highlight the tunnel
 	private boolean shouldHighlightTunnel = false;
@@ -476,9 +471,7 @@ public class GemstoneCrabTimerPlugin extends Plugin
 			log.debug("Gemstone Crab boss spawned");
 			bossPresent = true;
 			notificationSent = false;
-			fightEnded = false;
-			AFK = true;
-			
+
 			// Start a new DPS tracking session
 			// This is where we reset stats - when a new boss spawns
 			resetDpsTracking();
@@ -498,7 +491,6 @@ public class GemstoneCrabTimerPlugin extends Plugin
 		{
 			log.debug("Gemstone Crab boss despawned");
 			bossPresent = false;
-			fightEnded = true;
 			
 			// Finalize DPS tracking but don't reset stats
 			if (fightInProgress)
@@ -652,7 +644,6 @@ public class GemstoneCrabTimerPlugin extends Plugin
 					log.debug("Gemstone Crab successfully mined!");
 					miningAttempts++;
 					minedCount++;
-					AFK = false;
 					setLastMiningAttempt();
 				}
 			} else if (message.equalsIgnoreCase(GEMSTONE_CRAB_MINE_FAIL_MESSAGE)) {
@@ -660,7 +651,6 @@ public class GemstoneCrabTimerPlugin extends Plugin
 					log.debug("Failed to mine Gemstone Crab!");
 					miningAttempts++;
 					miningFailedCount++;
-					AFK = false;
 					setLastMiningAttempt();
 				}		
 			} else if (message.contains(GEMSTONE_CRAB_GEM_MINE_MESSAGE)) {
@@ -809,27 +799,6 @@ public class GemstoneCrabTimerPlugin extends Plugin
 		if (nearestTunnel != null && gameObject.getId() == TUNNEL_OBJECT_ID && gameObject.equals(nearestTunnel))
 		{
 			nearestTunnel = null;
-		}
-	}
-	
-	@Subscribe
-	public void onMenuOptionClicked(MenuOptionClicked event)
-	{
-		// Check if the player clicked on a tunnel
-		if (event.getMenuAction() == MenuAction.GAME_OBJECT_FIRST_OPTION || 
-			event.getMenuAction() == MenuAction.GAME_OBJECT_SECOND_OPTION || 
-			event.getMenuAction() == MenuAction.GAME_OBJECT_THIRD_OPTION || 
-			event.getMenuAction() == MenuAction.GAME_OBJECT_FOURTH_OPTION || 
-			event.getMenuAction() == MenuAction.GAME_OBJECT_FIFTH_OPTION)
-		{
-			int objectId = event.getId();
-			
-			// If the player clicked on a tunnel, mark it as interacted
-			if (objectId == TUNNEL_OBJECT_ID)
-			{
-				log.debug("Player interacted with tunnel");
-				AFK = false;
-			}
 		}
 	}
 

--- a/src/main/java/com/gimserenity/GemstoneCrabTimerPlugin.java
+++ b/src/main/java/com/gimserenity/GemstoneCrabTimerPlugin.java
@@ -771,10 +771,10 @@ public class GemstoneCrabTimerPlugin extends Plugin
 			}
 			
 			// Calculate current HP percentage (0-100)
-			int hpPercent = (int) (((double) healthRatio / (double) healthScale) * 100);
+			double hpPercent = (((double) healthRatio / (double) healthScale) * 100);
 			
 			// Check if HP is at or below the threshold
-			if (hpPercent <= (config.hpThreshold() - 0.5) && !notificationSent)
+			if (hpPercent <= (config.hpThreshold()) && !notificationSent)
 			{
 				notificationSent = true;
 				notifier.notify(config.hpThresholdNotification(), config.notificationMessage() + " (" + hpPercent + "% HP)");

--- a/src/main/java/com/gimserenity/GemstoneCrabTimerPlugin.java
+++ b/src/main/java/com/gimserenity/GemstoneCrabTimerPlugin.java
@@ -391,6 +391,14 @@ public class GemstoneCrabTimerPlugin extends Plugin
 		pendingCombatXp = 0;
 		lastXp.clear();
 	}
+
+	private void resetTunnel()
+	{
+		if(!tunnels.isEmpty())
+		{
+			shouldHighlightTunnel = false;
+		}
+	}
 	
 	/*
 	 * Load any saved configuration values
@@ -471,7 +479,8 @@ public class GemstoneCrabTimerPlugin extends Plugin
 			log.debug("Gemstone Crab boss spawned");
 			bossPresent = true;
 			notificationSent = false;
-
+	
+			resetTunnel();
 			// Start a new DPS tracking session
 			// This is where we reset stats - when a new boss spawns
 			resetDpsTracking();

--- a/src/main/java/com/gimserenity/GemstoneCrabTimerPlugin.java
+++ b/src/main/java/com/gimserenity/GemstoneCrabTimerPlugin.java
@@ -767,7 +767,7 @@ public class GemstoneCrabTimerPlugin extends Plugin
 			if (hpPercent <= (config.hpThreshold()) && !notificationSent)
 			{
 				notificationSent = true;
-				notifier.notify(config.hpThresholdNotification(), config.notificationMessage() + " (" + hpPercent + "% HP)");
+				notifier.notify(config.hpThresholdNotification(), config.notificationMessage() + " (" + config.hpThreshold() + "% HP)");
 				log.debug("Sent notification for Gemstone Crab at {}% HP", hpPercent);
 			}
 		}

--- a/src/main/java/com/gimserenity/GemstoneCrabTimerPlugin.java
+++ b/src/main/java/com/gimserenity/GemstoneCrabTimerPlugin.java
@@ -774,7 +774,7 @@ public class GemstoneCrabTimerPlugin extends Plugin
 			int hpPercent = (int) (((double) healthRatio / (double) healthScale) * 100);
 			
 			// Check if HP is at or below the threshold
-			if (hpPercent <= config.hpThreshold() && !notificationSent)
+			if (hpPercent <= (config.hpThreshold() - 0.5) && !notificationSent)
 			{
 				notificationSent = true;
 				notifier.notify(config.hpThresholdNotification(), config.notificationMessage() + " (" + hpPercent + "% HP)");


### PR DESCRIPTION
- Fix: Also reset tunnel highlight when boss respawns (same area)
- Fix: Changed time left & notification to use getHealthRatio and getHealthScale instead of reading widget, this allows all HP bar configurations to work
- Removed unused variables, imports and now redundant methods