### PR TITLE
Added spawn notification configuration option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build
+bin
 .idea/
 .project
 .settings/

--- a/src/main/java/com/gimserenity/GemstoneCrabTimerConfig.java
+++ b/src/main/java/com/gimserenity/GemstoneCrabTimerConfig.java
@@ -20,11 +20,23 @@ public interface GemstoneCrabTimerConfig extends Config
 	String notificationList = "notificationList";
 
 	@ConfigItem(
+		keyName = "nextSpawnNotification",
+		name = "Next Spawn Notification",
+		description = "Show a notification when the next Gemstone Crab spawns",
+		section = notificationList,
+		position = 0
+	)
+	default Notification nextSpawnNotification()
+	{
+		return Notification.OFF;
+	}
+
+	@ConfigItem(
 		keyName = "hpThresholdNotification",
 		name = "HP Threshold Notification",
 		description = "Show a notification when the Gemstone Crab reaches the HP threshold",
 		section = notificationList,
-		position = 0
+		position = 1
 	)
 	default Notification hpThresholdNotification()
 	{
@@ -40,7 +52,7 @@ public interface GemstoneCrabTimerConfig extends Config
 		name = "HP Threshold %",
 		description = "Send notification when Gemstone Crab HP reaches this percentage",
 		section = notificationList,
-		position = 1
+		position = 2
 	)
 	default int hpThreshold()
 	{
@@ -49,10 +61,10 @@ public interface GemstoneCrabTimerConfig extends Config
 	
 	@ConfigItem(
 		keyName = "notificationMessage",
-		name = "Notification Message",
+		name = "HP Threshold Notification Message",
 		description = "Message to show in the notification",
 		section = notificationList,
-		position = 2
+		position = 3
 	)
 	default String notificationMessage()
 	{


### PR DESCRIPTION
Added a separate notifiction for when the next crab spawns, so you don't have to wait around for a few seconds when going through the tunnel waiting for it to spawn. It works both with or without the existing hp threshold notification.

You do lose ~5-10 seconds of training time (depending on distance to tunnel and load time), so perhaps the notification delay could be reduced by a few seconds to give the player time to get through the tunnel as it spawns, rather arriving after the spawn? Maybe a configurable delay? However I think keeping it as is maximises effective AFK time.

I didn't add any tests as I noticed the other notifications didn't have any, as well as no README/version updates. Let me know if this should be added.